### PR TITLE
Avoid double dirlisting on expand

### DIFF
--- a/packages/tree-finder/src/model/model.ts
+++ b/packages/tree-finder/src/model/model.ts
@@ -143,7 +143,7 @@ export class ContentsModel<T extends IContentRow> {
     async expand(rix: number) {
         const content = this._contents[rix];
 
-        content.expand();
+        await content.expand();
         for (const child of (await content?.getChildren()) ?? []) {
             this._parentMap.set(child.row, content.row);
         }


### PR DESCRIPTION
Previously, an expand call would result in a double `getChildren` for directory contents:
1. For the `content.expand()` call.
2. For the `content.getChildren()` call.

Since `content.expand()` calls `getChildren()` internally, and the call is cached, we can avoid this double call by awaiting the expand call (previously both would go past the cache check if the actual dirlisting is slow).